### PR TITLE
Change span to a textarea with click-to-select

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ layout: spotifyauth
 ## Your Approval Code is:
 
 <div class="approvalDiv">
-<span id="approvalCode"></span>
+  <textarea id="approvalCode" readonly placeholder="Approval code will appear here"></textarea>
 </div>
 #### Copy paste the text above into the *Approval Code* field.
-If the blue box is empty you probably have something blocking Javascript in your browser.
+If the text box is empty you probably have something blocking Javascript in your browser.

--- a/spotifyauth.css
+++ b/spotifyauth.css
@@ -1,9 +1,18 @@
 .approvalDiv {
-	background: #6495ed;
-	height:260px;
+	background:#6495ed;
+	height:200px;
 	width:680px;
 	overflow-wrap:break-word;
-	padding-bottom:20px;
+	padding:20px;
+	box-sizing:border-box;
+}
+
+textarea {
+	resize:none;
+	width:100%;
+	height:100%;
+	padding:10px;
+	box-sizing:border-box;
 }
 
 .warningDiv {

--- a/spotifyauth.js
+++ b/spotifyauth.js
@@ -1,5 +1,7 @@
-$().ready(function() {
-   var urlParams = new URLSearchParams(window.location.search);
-   var codeParam = urlParams.get('code');
-   $("#approvalCode").html(codeParam);
+$(() => {
+	const urlParams = new URLSearchParams(window.location.search);
+	const codeParam = urlParams.get('code');
+	const approvalCode = $("#approvalCode");
+	approvalCode.val(codeParam);
+	approvalCode.click(() => approvalCode.select());
 });


### PR DESCRIPTION
This PR changes the span element to a textarea with a special click-to-select helper to speed up copying this approval code. With the span sometimes you could copy an extra space character but the textarea does not have this problem. The styling is also changes to be easier to read.